### PR TITLE
fix: createsuperuser가 제대로 되지 않는 이슈 수정

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ cryptography==36.0.1
 defusedxml==0.7.1
 Deprecated==1.2.13
 dj-rest-auth==2.2.2
-Django>=3.2.11
+Django==3.2.11
 django-allauth==0.47.0
 django-cors-headers==3.11.0
 django-environ==0.8.1

--- a/user/models/sns_account.py
+++ b/user/models/sns_account.py
@@ -1,5 +1,5 @@
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class SnsAccount(models.Model):

--- a/user/models/user.py
+++ b/user/models/user.py
@@ -38,7 +38,8 @@ class UserManager(BaseUserManager):
 class User(AbstractBaseUser, PermissionsMixin):
     """Model definition for User."""
 
-    USERNAME_FIELD = "email"
+    USERNAME_FIELD = "username"
+    REQUIRED_FIELDS = ["email"]
 
     email = models.EmailField(
         verbose_name=_("email"),


### PR DESCRIPTION
## 작업 내용
- createsuperuser가 제대로 되지 않는 이슈 수정
- ugettext_lazy deprecated issue

## 참고 사항
- ugettext_lazy → gettext_lazy로 사용해야 합니다.
- [아직 django-taggit-serializer 이를 반영안해서..](https://github.com/glemmaPaul/django-taggit-serializer/pull/48/files) django 버전을 낮추었습니다. ㅠㅠ
- 따라서, pip install -r requirements.txt를 한번 수행해주세요..