### PR TITLE
GitHub collector - README.md 배제하기

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.8 (ttl_api)" project-jdk-type="Python SDK" />
   <component name="PyCharmProfessionalAdvertiser">
     <option name="shown" value="true" />
   </component>

--- a/.idea/ttl_api.iml
+++ b/.idea/ttl_api.iml
@@ -2,7 +2,7 @@
 <module type="PYTHON_MODULE" version="4">
   <component name="NewModuleRootManager">
     <content url="file://$MODULE_DIR$" />
-    <orderEntry type="inheritedJdk" />
+    <orderEntry type="jdk" jdkName="Python 3.8 (ttl_api)" jdkType="Python SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
 </module>

--- a/utils/analyze_github_til.py
+++ b/utils/analyze_github_til.py
@@ -4,6 +4,7 @@ import shutil
 import aiofiles
 import asyncio
 
+"""github_collector mac version"""
 
 class AnalyzeGithubTil:
     def __init__(self, username, repository):
@@ -41,6 +42,8 @@ class AnalyzeGithubTil:
 
         tasks = set()
         for path, file_name in path_list:
+            if file_name == "README.md" or file_name == "readme.md":    # readme 파일을 제외
+                continue
             tasks.add(self.get_file_content(path, file_name))
 
         asyncio.run(asyncio.wait(tasks))

--- a/utils/analyze_github_til_win.py
+++ b/utils/analyze_github_til_win.py
@@ -4,6 +4,7 @@ import shutil
 import aiofiles
 import asyncio
 
+"""github_collector window version"""
 
 class AnalyzeGithubTil:
     def __init__(self, username, repository):
@@ -41,6 +42,8 @@ class AnalyzeGithubTil:
 
         tasks = set()
         for path, file_name in path_list:
+            if file_name == "README.md" or file_name == "readme.md":    # readme 파일을 제외
+                continue
             tasks.add(self.get_file_content(path, file_name))
 
         asyncio.run(asyncio.wait(tasks))

--- a/utils/analyze_github_til_win.py
+++ b/utils/analyze_github_til_win.py
@@ -1,0 +1,56 @@
+from git import Repo
+import os
+import shutil
+import aiofiles
+import asyncio
+
+
+class AnalyzeGithubTil:
+    def __init__(self, username, repository):
+        self.username = username
+        self.repository = repository
+        self.results = []
+
+    def clone_repositry(self):
+        """Repository를 특정 디렉토리에 Clone 합니다."""
+        Repo.clone_from(
+            f"https://github.com/{self.username}/{self.repository}",
+            f".anaylze\{self.username}\{self.repository}",
+        )
+
+    def get_markdown_file_path_list(self):
+        """Clone한 레포지터리를 탐색하면서 md 파일 목록을 뽑아냅니다."""
+        file_paths = []
+        for top, _, files in os.walk(f".anaylze\{self.username}\{self.repository}"):
+            for file_name in files:
+                if file_name[-3:] == ".md":
+                    file_paths.append([os.path.join(top, file_name), file_name])
+
+        return file_paths
+
+    async def get_file_content(self, path, file_name):
+        """비동기로 파일을 읽어낸 후, 파일명과 파일 내용을 담아냅니다."""
+        async with aiofiles.open(path, mode="r", encoding='utf-8') as f:
+            content = await f.read()
+            self.results.append([file_name[:-3], content])
+
+    def perform(self):
+        """메인 job 수행 메서드"""
+        self.clone_repositry()
+        path_list = self.get_markdown_file_path_list()
+
+        tasks = set()
+        for path, file_name in path_list:
+            tasks.add(self.get_file_content(path, file_name))
+
+        asyncio.run(asyncio.wait(tasks))
+
+    def __del__(self):
+        """작업을 마치면, 클론한 디렉토리를 제거합니다."""
+        shutil.rmtree(f".anaylze\{self.username}\{self.repository}", ignore_errors=True)
+
+
+if __name__ == "__main__":
+    t = AnalyzeGithubTil("shinkeonkim", "TIL")
+    t.perform()
+    print(t.results)


### PR DESCRIPTION
## 작업 내용
- 윈도우와 맥의 디렉토리 구분이 \와 /로 달라 실행 시 오류가 있었습니다.
- 이를 위해 윈도우버전 추합기를 새로 만들었습니다.
- README.md를 배제하기 위해 get_file_content 함수를 실행하기 전 조건문을 사용해 배제시켰습니다.
- git에서는 readme.md파일이 대소문자 구분없이(?) 인식되어 혹시나 readme.md를 사용한 사용자가 있을까싶어 readme.md 파일또한 제외시켰습니다.

## 참고 사항
- 윈도우 버전의 추합기를 만들며 여러 오류가 있었습니다....ㅜㅠ 
- 어찌저찌 돌아가나 AnalyzeGithubTil 클래스의 소멸메소드가 제대로 실행되지 않습니다. 
     (파일 내용들은 지워지나 파일 디렉토리와 .git 파일이 지워지지 않음. -> 윈도우에서 해당 폴더권한이 막혀있어서 생긴문제?)
- 이게 나중에 어떤 문제를 일으킬진 모르지만... 일단은 어... 실행은 됩니다.....

## 기타 사항
-  사실 readme.md를 제외하기 위해 코드 두줄만 추가해서 ... 딱히 크게 한 작업은 없는 것 같네요 ... (오류로 고생하기뿐..)
- 주석을 달아야할까 말까 고민이 되었습니다. 그냥 달긴했는데 왠지 지워도 될것같아요... 의견주세요..!