### PR TITLE
root url에서 404 대신 swagger 화면이 뜨도록 함.

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -38,6 +38,11 @@ schema_view = get_schema_view(
     permission_classes=(permissions.AllowAny,),
 )
 urlpatterns = [
+    path(
+        "",
+        schema_view.with_ui("swagger", cache_timeout=0),
+        name="schema-swagger-ui",
+    ),
     path("admin/", admin.site.urls),
     path("api/users/", include("user.urls")),
     path("api/articles/", include("article.urls")),


### PR DESCRIPTION
## 작업 내용
- root url에서 404 대신 swagger 화면이 뜨도록 함.

## 참고 사항
- 루트화면에서 404가 떠서 제대로 연결이되어있지 않나 혼동되는 일이 있어서, 임의로 swagger 화면을 연결했습니다.