### PR TITLE
feat: is_feedbacked 추가

### DIFF
--- a/article/serializers/__init__.py
+++ b/article/serializers/__init__.py
@@ -1,4 +1,6 @@
 from .article_serializer import ArticleSerializer
+from .article_sub_serializer import ArticleSubSerializer
+from .article_list_serializer import ArticleListSerializer
 from .bookmark_serializer import BookmarkSerializer
 from .feedback_serializer import FeedbackSerializer
 from .upload_image_serializer import UploadImageSerializer

--- a/article/serializers/article_list_serializer.py
+++ b/article/serializers/article_list_serializer.py
@@ -20,6 +20,7 @@ class ArticleListSerializer(TaggitSerializer, WritableNestedModelSerializer):
     )
     feedback = serializers.SerializerMethodField()
     is_bookmarked = serializers.SerializerMethodField()
+    is_feedbacked = serializers.SerializerMethodField()
 
     class Meta:
         """Meta definition for ArticleSerializer."""
@@ -36,6 +37,7 @@ class ArticleListSerializer(TaggitSerializer, WritableNestedModelSerializer):
             "feedback_count",
             "bookmark_count",
             "is_bookmarked",
+            "is_feedbacked",
             "feedback",
             "created_at",
             "updated_at",
@@ -48,6 +50,7 @@ class ArticleListSerializer(TaggitSerializer, WritableNestedModelSerializer):
             "feedback_count",
             "bookmark_count",
             "is_bookmarked",
+            "is_feedbacked",
             "feedback",
             "created_at",
             "updated_at",
@@ -66,5 +69,13 @@ class ArticleListSerializer(TaggitSerializer, WritableNestedModelSerializer):
             user = self.context["request"].user
 
             return obj.bookmarks.filter(user=user).exists()
+        except:
+            return False
+
+    def get_is_feedbacked(self, obj):
+        try:
+            user = self.context["request"].user
+
+            return obj.feedbacks.filter(user=user).exists()
         except:
             return False

--- a/article/serializers/article_serializer.py
+++ b/article/serializers/article_serializer.py
@@ -20,6 +20,7 @@ class ArticleSerializer(TaggitSerializer, WritableNestedModelSerializer):
     )
     feedback = serializers.SerializerMethodField()
     is_bookmarked = serializers.SerializerMethodField()
+    is_feedbacked = serializers.SerializerMethodField()
 
     class Meta:
         """Meta definition for ArticleSerializer."""
@@ -37,6 +38,7 @@ class ArticleSerializer(TaggitSerializer, WritableNestedModelSerializer):
             "bookmark_count",
             "is_bookmarked",
             "feedback",
+            "is_feedbacked",
             "created_at",
             "updated_at",
         ]
@@ -49,6 +51,7 @@ class ArticleSerializer(TaggitSerializer, WritableNestedModelSerializer):
             "bookmark_count",
             "is_bookmarked",
             "feedback",
+            "is_feedbacked",
             "created_at",
             "updated_at",
         ]
@@ -66,5 +69,13 @@ class ArticleSerializer(TaggitSerializer, WritableNestedModelSerializer):
             user = self.context["request"].user
 
             return obj.bookmarks.filter(user=user).exists()
+        except:
+            return False
+
+    def get_is_feedbacked(self, obj):
+        try:
+            user = self.context["request"].user
+
+            return obj.feedbacks.filter(user=user).exists()
         except:
             return False

--- a/article/serializers/article_sub_serializer.py
+++ b/article/serializers/article_sub_serializer.py
@@ -1,0 +1,60 @@
+from django.db.models import Count
+from rest_framework import serializers
+
+from article.models import Article, Feedback
+
+
+class ArticleSubSerializer(serializers.ModelSerializer):
+    """Serializer definition for Article Model."""
+
+    feedback = serializers.SerializerMethodField()
+    is_bookmarked = serializers.SerializerMethodField()
+    is_feedbacked = serializers.SerializerMethodField()
+
+    class Meta:
+        """Meta definition for ArticleSubSerializer."""
+        model = Article
+
+        fields = [
+            "id",
+            "study_count",
+            "feedback",
+            "is_bookmarked",
+            "is_feedbacked",
+            "feedback_count",
+            "bookmark_count",
+        ]
+
+        read_only_fields = [
+            "id",
+            "study_count",
+            "feedback",
+            "is_bookmarked",
+            "is_feedbacked",
+            "feedback_count",
+            "bookmark_count",
+        ]
+
+    def get_feedback(self, obj):
+        return (
+            Feedback.objects.filter(article=obj)
+            .values("category")
+            .annotate(total=Count("category"))
+            .order_by("-total")
+        )
+
+    def get_is_bookmarked(self, obj):
+        try:
+            user = self.context["request"].user
+
+            return obj.bookmarks.filter(user=user).exists()
+        except:
+            return False
+
+    def get_is_feedbacked(self, obj):
+        try:
+            user = self.context["request"].user
+
+            return obj.feedbacks.filter(user=user).exists()
+        except:
+            return False

--- a/article/views/article_list_create_api_view.py
+++ b/article/views/article_list_create_api_view.py
@@ -16,7 +16,7 @@ from user.models import Follow, Grass
 
 class ArticleListCreateAPIView(BaseView, ListCreateAPIView):
     serializer_class = ArticleSerializer
-    queryset = Article.objects.all().prefetch_related("bookmarks")
+    queryset = Article.objects.all().prefetch_related("bookmarks", "feedbacks")
     permission_classes = [IsAuthenticatedOrReadOnly]
     filter_backends = [filters.SearchFilter, filters.OrderingFilter, TagFilter]
     search_fields = ["title", "content"]

--- a/article/views/article_retrieve_update_destroy_api_view.py
+++ b/article/views/article_retrieve_update_destroy_api_view.py
@@ -11,7 +11,7 @@ from rest_framework.response import Response
 
 class ArticleRetrieveUpdateDestroyAPIView(BaseView, RetrieveUpdateDestroyAPIView):
     serializer_class = ArticleSerializer
-    queryset = Article.objects.all()
+    queryset = Article.objects.all().prefetch_related("bookmarks", "feedbacks")
     permission_classes = [IsArticleEditableOrDestroyable]
 
     def get(self, request, *args, **kwargs):

--- a/article/views/article_sub_retrieve_api_view.py
+++ b/article/views/article_sub_retrieve_api_view.py
@@ -10,6 +10,8 @@ from rest_framework import serializers
 
 class ArticleSubSerializer(serializers.ModelSerializer):
     feedback = serializers.SerializerMethodField()
+    is_bookmarked = serializers.SerializerMethodField()
+    is_feedbacked = serializers.SerializerMethodField()
 
     class Meta:
         model = Article
@@ -18,6 +20,8 @@ class ArticleSubSerializer(serializers.ModelSerializer):
             "id",
             "study_count",
             "feedback",
+            "is_bookmarked",
+            "is_feedbacked",
             "feedback_count",
             "bookmark_count",
         ]
@@ -26,6 +30,8 @@ class ArticleSubSerializer(serializers.ModelSerializer):
             "id",
             "study_count",
             "feedback",
+            "is_bookmarked",
+            "is_feedbacked",
             "feedback_count",
             "bookmark_count",
         ]
@@ -37,6 +43,22 @@ class ArticleSubSerializer(serializers.ModelSerializer):
             .annotate(total=Count("category"))
             .order_by("-total")
         )
+
+    def get_is_bookmarked(self, obj):
+        try:
+            user = self.context["request"].user
+
+            return obj.bookmarks.filter(user=user).exists()
+        except:
+            return False
+
+    def get_is_feedbacked(self, obj):
+        try:
+            user = self.context["request"].user
+
+            return obj.feedbacks.filter(user=user).exists()
+        except:
+            return False
 
 
 class ArticleSubRetrieveAPIView(BaseView, RetrieveAPIView):

--- a/article/views/article_sub_retrieve_api_view.py
+++ b/article/views/article_sub_retrieve_api_view.py
@@ -9,7 +9,7 @@ from article.models import Article
 
 class ArticleSubRetrieveAPIView(BaseView, RetrieveAPIView):
     serializer_class = ArticleSubSerializer
-    queryset = Article.objects.all()
+    queryset = Article.objects.all().prefetch_related("bookmarks", "feedbacks")
     permission_classes = [AllowAny]
 
     def get(self, request, *args, **kwargs):

--- a/article/views/article_sub_retrieve_api_view.py
+++ b/article/views/article_sub_retrieve_api_view.py
@@ -1,64 +1,10 @@
-from django.db.models import Count
-
 from rest_framework.generics import RetrieveAPIView
-from config.views import BaseView
-from article.models import Article, Feedback
 from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
-from rest_framework import serializers
 
-
-class ArticleSubSerializer(serializers.ModelSerializer):
-    feedback = serializers.SerializerMethodField()
-    is_bookmarked = serializers.SerializerMethodField()
-    is_feedbacked = serializers.SerializerMethodField()
-
-    class Meta:
-        model = Article
-
-        fields = [
-            "id",
-            "study_count",
-            "feedback",
-            "is_bookmarked",
-            "is_feedbacked",
-            "feedback_count",
-            "bookmark_count",
-        ]
-
-        read_only_fields = [
-            "id",
-            "study_count",
-            "feedback",
-            "is_bookmarked",
-            "is_feedbacked",
-            "feedback_count",
-            "bookmark_count",
-        ]
-
-    def get_feedback(self, obj):
-        return (
-            Feedback.objects.filter(article=obj)
-            .values("category")
-            .annotate(total=Count("category"))
-            .order_by("-total")
-        )
-
-    def get_is_bookmarked(self, obj):
-        try:
-            user = self.context["request"].user
-
-            return obj.bookmarks.filter(user=user).exists()
-        except:
-            return False
-
-    def get_is_feedbacked(self, obj):
-        try:
-            user = self.context["request"].user
-
-            return obj.feedbacks.filter(user=user).exists()
-        except:
-            return False
+from article.serializers.article_sub_serializer import ArticleSubSerializer
+from config.views import BaseView
+from article.models import Article
 
 
 class ArticleSubRetrieveAPIView(BaseView, RetrieveAPIView):


### PR DESCRIPTION
## 작업 내용
- isFeedback article에서 분리하기
- article_list_serializer, article_serializer, ArticleSubSerializer에 isFeedback 추가하였습니다.
- N+1 이슈를 해결하기위해 prefetch_related를 사용했습니다.

## 참고 사항
- 댓글을 달거나, 피드백을 남기거나, 북마크를 하거나 등 글 관련 api를 호출한다음에 프론트 단에서는 한번 api를 다시 호출해서 정보를 동기화합니다. 그래서 위 액션을 했을때도 조회수가 증가하는 이슈를 해결하기 위해 작업하였습니다. 
- ~~api view에 serializer가 있는 동공지진을 겪었지만 리팩토링할거니까... 눈 좀만 감고있을게요...~~
- api view에 있던 articleusbserializer 분리했습니다
- N+1 문제란? → 쿼리 1번으로 N건의 article을 가져왔는데 feedback, bookmark를 했는지를 얻기 위해 이 N건의 데이터를 데이터 수 만큼 반복해서 2차적으로 쿼리를 수행하는 문제

## 기타 사항
- 이전 코드들을 살펴보다 article_list_serializer에도isFeedback 필요할 것 같아 추가하였습니다.