### PR TITLE
fix: tab=study articles 재정렬

### DIFF
--- a/article/views/article_list_create_api_view.py
+++ b/article/views/article_list_create_api_view.py
@@ -59,9 +59,11 @@ class ArticleListCreateAPIView(BaseView, ListCreateAPIView):
                 studied_article_ids = Study.objects.filter(
                     user=self.current_user
                 ).values_list("article__id", flat=True)
-
-                queryset = queryset.filter(id__in=studied_article_ids)
-
+                
+                queryset = []
+                for studied_article_id in studied_article_ids:
+                    queryset.append(Article.objects.get(id = studied_article_id))
+                               
         if user_id is not None:
             queryset = queryset.filter(user__id=user_id)
 


### PR DESCRIPTION
## 작업 내용
- tab=study인 경우 조회한 순서대로 articles가 정렬되도록 했습니다. 

## 기타 사항
- 기존의 코드는 쿼리셋이 필터링 되면서 아티클이 생성됐던 순서대로 정렬이 되길래 일일히 이를 리스트에 추가하는 방식으로 바꾸었습니다. for 문 말고 더 효율적인 방법이 있을까 고민하다가 오래 걸렸는데 혹시 더 효율적인 방법이 있다면 알려주시면 감사하겠습니다..!
