### PR TITLE
fix: tab=study 인 경우 articles 를 조회순으로 정렬

### DIFF
--- a/article/views/article_list_create_api_view.py
+++ b/article/views/article_list_create_api_view.py
@@ -59,8 +59,8 @@ class ArticleListCreateAPIView(BaseView, ListCreateAPIView):
                 studied_article_ids = Study.objects.filter(
                     user=self.current_user
                 ).values_list("article__id", flat=True)
-
-                queryset = queryset.filter(id__in=studied_article_ids)
+                
+                queryset = queryset.filter(id__in=studied_article_ids).order_by('studies')
 
         if user_id is not None:
             queryset = queryset.filter(user__id=user_id)


### PR DESCRIPTION
## 작업 내용
- articles 를 조회순으로 정렬했습니다.
- intersection 과 join 을 시도해봤는데 잘 되지 않았는데, studied 로 정렬하니 됐습니다. 

## 기타
- 로컬에서 테스트하면 조회순으로 잘 정렬이 되는데, 이렇게 하는게 맞는지 모르겠습니다..!
- 토요일에 시험이 있었어서 준비하느라 수정이 늦었던 점 죄송합니다..! (__)