### PR TITLE
web docker container - restart: always 옵션 추가

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,7 @@ services:
       && gunicorn config.wsgi -b 0.0.0.0:${PORT}"
     ports:
       - "${PORT}:${PORT}"
+    restart: always
     volumes:
       - .:/web
     depends_on:


### PR DESCRIPTION
## 작업 내용
- web container가 exit되었을 때,항상 다시 시작하도록 옵션을 추가했습니다.
- docker-compose up -d 이후 개발 중에 컨테이너가 꺼지는 불편함이 있었습니다.

## 참고 사항
- [요거](https://stackoverflow.com/questions/41555884/docker-what-does-docker-run-restart-always-actually-do) 참고해주세요.

